### PR TITLE
Fix typo in code of conduct

### DIFF
--- a/content/coc/index.html
+++ b/content/coc/index.html
@@ -26,7 +26,7 @@ description = "PDXKBC's Code of Conduct"
 <h2>Code of Conduct</h2>
 
 <p>
-  Every single person involved with or at the PDXKBC meetup, on the PDXKBX
+  Every single person involved with or at the PDXKBC meetup, on the PDXKBC
   subreddit, or on the PDXKBC Discord is required to follow this code of
   conduct.
 </p>

--- a/content/coc/index.html
+++ b/content/coc/index.html
@@ -26,7 +26,7 @@ description = "PDXKBC's Code of Conduct"
 <h2>Code of Conduct</h2>
 
 <p>
-  Every single person at the involved at the PDXKBC meetup, on the PDXKBX
+  Every single person involved with or at the PDXKBC meetup, on the PDXKBX
   subreddit, or on the PDXKBC Discord is required to follow this code of
   conduct.
 </p>
@@ -78,7 +78,9 @@ description = "PDXKBC's Code of Conduct"
 </p>
 
 <p>
-  <a href="/" class="dark-blue hover-blue no-underline ba bw1 br2 db pv2 ph3 mv4"
+  <a
+    href="/"
+    class="dark-blue hover-blue no-underline ba bw1 br2 db pv2 ph3 mv4"
     >&lsaquo; Back to pdxkbc.com</a
   >
 </p>


### PR DESCRIPTION
Got an email from grapeis@protonmail.com saying that there was a typo in the Code of Conduct. This fixes the typo they reported.